### PR TITLE
logsuccessとlogtraceの追加，Node_templateのinitでloglevelを指定できるように

### DIFF
--- a/src/tamlib/node_template/base.py
+++ b/src/tamlib/node_template/base.py
@@ -24,20 +24,6 @@ class Node(NodeABC, Publisher, Subscriber, Action, Logger):
         for sub in self.sub.values():
             sub.unregister()
 
-    # def logdebug(self, message) -> None:
-    #     rospy.logdebug(f"[{self.node_name}]: {message}")
-
-    # def loginfo(self, message) -> None:
-    #     rospy.loginfo(f"[{self.node_name}]: {message}")
-
-    # def logwarn(self, message) -> None:
-    #     rospy.logwarn(f"[{self.node_name}]: {message}")
-
-    # def logerr(self, message) -> None:
-    #     rospy.logerr(f"[{self.node_name}]: {message}")
-
-    # def logfatal(self, message) -> None:
-    #     rospy.logfatal(f"[{self.node_name}]: {message}")
 
     def set_update_ros_time(self, name: Optional[str] = None) -> None:
         """更新時間（ROS時間）をセットする

--- a/src/tamlib/node_template/base.py
+++ b/src/tamlib/node_template/base.py
@@ -10,12 +10,12 @@ from .base_abc import NodeABC
 
 
 class Node(NodeABC, Publisher, Subscriber, Action, Logger):
-    def __init__(self) -> None:
+    def __init__(self, loglevel='INFO') -> None:
         super().__init__()
         Publisher.__init__(self)
         Subscriber.__init__(self)
         Action.__init__(self)
-        Logger.__init__(self)
+        Logger.__init__(self, loglevel=loglevel)
 
         self.run_enable = rospy.get_param(self.node_name + "/run_enable", True)
         rospy.Service(self.node_name + "/run_enable", SetBool, self.set_run_enable)

--- a/src/tamlib/utils/logger.py
+++ b/src/tamlib/utils/logger.py
@@ -44,11 +44,17 @@ class Logger:
         """
         self._logger.add(path, level=loglevel)
 
+    def logtrace(self, message) -> None:
+        self._logger.opt(depth=1).trace(message)
+
     def logdebug(self, message) -> None:
         self._logger.opt(depth=1).debug(message)
 
     def loginfo(self, message: str) -> None:
         self._logger.opt(depth=1).info(message)
+        
+    def logsuccess(self, message) -> None:
+        self._logger.opt(depth=1).success(message)
 
     def logwarn(self, message: str) -> None:
         self._logger.opt(depth=1).warning(message)


### PR DESCRIPTION
logsuccessとlogtraceが実装されてなかったので，実装．
loglevelは TRACE -> DEBUG -> INFO -> SUCCESS -> WARNING -> ERROR -> CRITICALの順で上がっていく．

Node_templateを継承したクラスの初期化時に引数として与えることで，loglevelの変更が可能
```python
class HOGE(Node):
    def __init__(self):
        super().__init__(loglevel="DEBUG")
```